### PR TITLE
ref #476: implemented related queries API

### DIFF
--- a/newscout_web/api/v1/urls.py
+++ b/newscout_web/api/v1/urls.py
@@ -37,7 +37,8 @@ from .views import (
     DomainsListAPIView,
     UsersListAPIView,
     SendInvitationView,
-    SyncEtherpadView
+    SyncEtherpadView,
+    RelatedAPIView,
 )
 from django.conf.urls import url, include
 
@@ -49,27 +50,51 @@ schema_view = get_swagger_view(title="Newscout API Documentation")
 
 
 url_router = DefaultRouter()
-url_router.register(r"article/draft-image", DraftMediaUploadViewSet, basename="draft-media")
+url_router.register(
+    r"article/draft-image", DraftMediaUploadViewSet, basename="draft-media"
+)
 url_router.register(r"comment", CommentViewSet, basename="comment")
 
 urlpatterns = [
     url("", include(url_router.urls)),
     url(r"^documentation/", schema_view),
     url(r"^trending/$", TrendingArticleAPIView.as_view(), name="trending"),
-    url(r"^categories/bulk/$", CategoryBulkUpdate.as_view(), name="category-bulk-update"),
+    url(
+        r"^categories/bulk/$", CategoryBulkUpdate.as_view(), name="category-bulk-update"
+    ),
     url(r"^categories/$", CategoryListAPIView.as_view(), name="category-list"),
     url(r"^articles/$", ArticleListAPIView.as_view(), name="articles-list"),
-    url(r"^articles/like-news-list/$", ArticleLikeAPIView.as_view(), name="users-articles-list"),
-    url(r"^bookmark-articles/bookmark-news-list/$", BookmarkArticleAPIView.as_view(), name="user-bookmarks"),
+    url(
+        r"^articles/like-news-list/$",
+        ArticleLikeAPIView.as_view(),
+        name="users-articles-list",
+    ),
+    url(
+        r"^bookmark-articles/bookmark-news-list/$",
+        BookmarkArticleAPIView.as_view(),
+        name="user-bookmarks",
+    ),
     url(r"^tags/$", HashTagAPIView.as_view(), name="hash-tags"),
     url(r"^tags/save/$", UserHashTagAPIView.as_view(), name="save-tags"),
     url(r"^source/$", SourceListAPIView.as_view(), name="source-list"),
     url(r"^domains/$", DomainsListAPIView.as_view(), name="domains-list"),
     url(r"^users/$", UsersListAPIView.as_view(), name="users-list"),
     url(r"^articles/vote/$", ArticleDetailAPIView.as_view(), name="vote-article"),
-    url(r"^articles/bookmark/$", ArticleBookMarkAPIView.as_view(), name="bookmark-article"),
-    url(r"^articles/(?P<slug>[\w-]+)/$", ArticleDetailAPIView.as_view(), name="articles-list"),
-    url(r"^articles/(?P<article_id>[-\d]+)/recommendations/$", ArticleRecommendationsAPIView.as_view(), name="articles-list"),
+    url(
+        r"^articles/bookmark/$",
+        ArticleBookMarkAPIView.as_view(),
+        name="bookmark-article",
+    ),
+    url(
+        r"^articles/(?P<slug>[\w-]+)/$",
+        ArticleDetailAPIView.as_view(),
+        name="articles-list",
+    ),
+    url(
+        r"^articles/(?P<article_id>[-\d]+)/recommendations/$",
+        ArticleRecommendationsAPIView.as_view(),
+        name="articles-list",
+    ),
     url(r"^signup/$", SignUpAPIView.as_view(), name="signup"),
     url(r"^login/$", LoginAPIView.as_view(), name="login"),
     url(r"^logout/$", LogoutAPIView.as_view(), name="logout"),
@@ -80,14 +105,23 @@ urlpatterns = [
     url(r"^device/$", DevicesAPIView.as_view(), name="device"),
     url(r"^notification/$", NotificationAPIView.as_view(), name="notification"),
     url(r"^social-login/$", SocialLoginView.as_view(), name="social-login"),
-    url(r"^article/create-update/$", ArticleCreateUpdateView.as_view(), name="article-create-update"),
+    url(
+        r"^article/create-update/$",
+        ArticleCreateUpdateView.as_view(),
+        name="article-create-update",
+    ),
     url(r"^article/status/$", ChangeArticleStatusView.as_view(), name="article-status"),
     url(r"^suggest/$", AutoCompleteAPIView.as_view(), name="suggest"),
+    url(r"^related/$", RelatedAPIView.as_view(), name="related"),
     url(r"daily-digest/$", GetDailyDigestView.as_view(), name="daily-digest"),
     url(r"article-like/$", LikeAPIView.as_view(), name="article-like"),
     url(r"comment-captcha/$", CaptchaCommentApiView.as_view(), name="comment-captcha"),
     url(r"subscription/$", SubsAPIView.as_view(), name="subscriptions-api"),
-    url(r"subscription/(?P<pk>[\w-]+)/$", UpdateSubsAPIView.as_view(), name="update-subscriptions-api"),
+    url(
+        r"subscription/(?P<pk>[\w-]+)/$",
+        UpdateSubsAPIView.as_view(),
+        name="update-subscriptions-api",
+    ),
     url(r"userprofile/$", UserProfileAPIView.as_view(), name="userprofile"),
     url(r"access-session/$", AccessSession.as_view(), name="access-session-api"),
     url(r"rss/$", RSSAPIView.as_view(), name="rss-api"),

--- a/newscout_web/core/utils.py
+++ b/newscout_web/core/utils.py
@@ -7,13 +7,9 @@ from elasticsearch import Elasticsearch
 
 
 es = Elasticsearch(
-    hosts=[
-        {
-            'host': settings.ELASTIC_SERVER_IP,
-            'port': settings.ELASTIC_SERVER_PORT
-        }
-    ]
+    hosts=[{"host": settings.ELASTIC_SERVER_IP, "port": settings.ELASTIC_SERVER_PORT}]
 )
+
 
 def create_index(index, mapping=None):
     """
@@ -24,9 +20,9 @@ def create_index(index, mapping=None):
             es.indices.create(index=index, body=mapping)
         else:
             es.indices.create(index=index)
-        print ("Created Index >>>>>>>>>>> " + index)
+        print("Created Index >>>>>>>>>>> " + index)
     else:
-        print ("Index Already exsits >>>>>>>>>>> " + index)
+        print("Index Already exsits >>>>>>>>>>> " + index)
 
 
 def delete_existing_index(index):
@@ -36,9 +32,9 @@ def delete_existing_index(index):
     """
     if es.indices.exists(index):
         es.indices.delete(index=index)
-        print ("Deleted Index >>>>>>>>>>> " + index)
+        print("Deleted Index >>>>>>>>>>> " + index)
     es.indices.create(index=index)
-    print ("Created Index >>>>>>>>>>> " + index)
+    print("Created Index >>>>>>>>>>> " + index)
 
 
 def create_mapping_for_index(index, mapping):
@@ -48,9 +44,9 @@ def create_mapping_for_index(index, mapping):
     """
     if es.indices.exists(index):
         es.indices.delete(index=index)
-        print ("Deleted Index >>>>>>>>>>> " + index)
+        print("Deleted Index >>>>>>>>>>> " + index)
     es.indices.create(index=index, body=mapping)
-    print ("Created Index >>>>>>>>>>> " + index)
+    print("Created Index >>>>>>>>>>> " + index)
 
 
 def ingest_to_elastic(docs, index, item_type, item_id):
@@ -60,7 +56,7 @@ def ingest_to_elastic(docs, index, item_type, item_id):
         action = {
             "_index": index,
             "_id": md5(str(item[item_id]).encode()).hexdigest(),
-            "_source": item
+            "_source": item,
         }
         if item_type:
             action["_type"] = item_type
@@ -77,7 +73,7 @@ def update_to_elastic(docs, index, item_type, item_id):
             "_index": index,
             "_type": item_type,
             "_id": md5(str(item[item_id]).encode()).hexdigest(),
-            "doc": item
+            "doc": item,
         }
         actions.append(action)
     helpers.bulk(es, actions, chunk_size=100, request_timeout=20)
@@ -91,7 +87,29 @@ def delete_from_elastic(docs, index, item_type, item_id):
             "_index": index,
             "_type": item_type,
             "_id": md5(str(item[item_id]).encode()).hexdigest(),
-            "doc": item
+            "doc": item,
         }
         actions.append(action)
     helpers.bulk(es, actions, index=index, refresh=True)
+
+
+def get_docs(index, start=0, size=25):
+    results = []
+    response = es.search(
+        index=index, body={"from": start, "size": size, "query": {"match_all": {}}}
+    )
+    if "hits" in response and "hits" in response["hits"]:
+        for current in response["hits"]["hits"]:
+            results.append(current["_source"]["desc"])
+    return results, response["hits"]["total"]
+
+
+def search_index(q, index, fields, start=0, size=100):
+    results = []
+    response = es.search(
+        index=index, body={"_source": fields, "from": start, "size": size, "query": q}
+    )
+    if "hits" in response and "hits" in response["hits"]:
+        for current in response["hits"]["hits"]:
+            results.append(current["_source"])
+    return results, response["hits"]["total"]


### PR DESCRIPTION
Following changes have been implemented:

1. Added new option "Ingest related-query suggestions" in `ingest_data_to_elastic.py`
2. Implemented a new API E.g. `/api/v1/related/?q=ONGC`
3. Added couple of functions `get_docs`, `search_index` in `utils.py`